### PR TITLE
passiv/konfig-cli@2.10.0 -> 2.11.1

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -18,4 +18,4 @@ runs:
 
     - name: Install CLI
       shell: bash
-      run: npm install -g @passiv/konfig-cli@2.10.0
+      run: npm install -g @passiv/konfig-cli@2.11.1


### PR DESCRIPTION
This is a PR to use the new konfig cli version that uses the updated schema. This should not break anything

Worst-case scenario, the SDKs fails to build due to a run-time validation I missed and we make a PR to set this number back to 2.10.0