### PR TITLE
Bump workflow Node runtime to 20 for TypeScript test compatibility

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "20"
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm

--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "20"
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm

--- a/docker/test-and-publish/Dockerfile
+++ b/docker/test-and-publish/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:20-bullseye
 
 RUN npm install -g pnpm 
 RUN apt-get update && apt-get install --no-install-recommends -y software-properties-common ca-certificates lsb-release apt-transport-https


### PR DESCRIPTION
### Motivation
- TypeScript integration tests were failing due to a dependency (`rolldown`) importing `styleText` from `node:util`, which requires a newer Node runtime than Node 18. 
- This repo provides the reusable CI workflows and the test/publish container used by SDK repos, so upgrading the pinned Node runtime here aligns CI with dependency requirements.

### Description
- Updated `actions/setup-node` `node-version` from `"18"` to `"20"` in `.github/workflows/regenerate-sdks.yaml` and `.github/workflows/bump.yaml`.
- Updated the test/publish container base image from `node:18-bullseye` to `node:20-bullseye` in `docker/test-and-publish/Dockerfile`.
- Committed the changes and created a PR so downstream SDK repos that use these workflows/containers will run tests on Node 20.

### Testing
- Ran repository scans and file inspections using `rg` and `sed` to locate relevant workflow and Dockerfile usages, which completed successfully.
- Verified the diffs with `git diff` and committed the changes with `git commit`, both of which succeeded.
- Created the PR record via the repository PR tooling and confirmed the updated files contain the new Node 20 references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f0f2270e88328a06cd5ebf6683939)