### PR TITLE
Upgrade GitHub Actions, Node.js, and build image to Node 24

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -63,9 +63,9 @@ jobs:
         working-directory: ${{ inputs.konfig_yaml_dir }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
-          node-version: "18"
+          node-version: "24"
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       sdk_submodule_dirs: ${{ steps.sdk-submodules.outputs.dirs }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           submodules: ${{ matrix.language == 'php' || matrix.language == 'php7' }}
@@ -116,8 +116,13 @@ jobs:
         with:
           TEST_ENV: ${{ secrets.TEST_ENV }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
       - name: Run tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -172,7 +177,7 @@ jobs:
           chmod 600 ~/.netrc
 
       - name: Publish SDKs
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3

--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -41,15 +41,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           submodules: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
-          node-version: "18"
+          node-version: "24"
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           submodules: true
@@ -154,7 +154,7 @@ jobs:
           TEST_ENV: ${{ secrets.TEST_ENV }}
 
       - name: Run tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -171,7 +171,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           submodules: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Find konfig.yaml files
         id: find-konfig-yamls

--- a/docker/test-and-publish/Dockerfile
+++ b/docker/test-and-publish/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:24-bullseye
 
 RUN npm install -g pnpm 
 RUN apt-get update && apt-get install --no-install-recommends -y software-properties-common ca-certificates lsb-release apt-transport-https


### PR DESCRIPTION
### Motivation

- Modernize CI by upgrading GitHub Action versions and the Node runtime to keep toolchain up-to-date.
- Ensure the test-and-publish container matches the updated Node version used in workflows.
- Improve reliability of retry logic by using a newer `nick-fields/retry` action version.

### Description

- Updated `actions/checkout` from `v3` to `v6` across workflow files (`bump.yaml`, `publish.yaml`, `regenerate-sdks.yaml`, `release.yaml`).
- Updated `actions/setup-node` from `v3` to `v5` and bumped `node-version` from `18` to `24` in workflows that set up Node, and added a `Set up Node.js` step in `publish.yaml` that uses `node-version: "24"`.
- Replaced `nick-fields/retry@v2` with `nick-fields/retry@v3` in `publish.yaml` and `regenerate-sdks.yaml` for test and publish retry steps.
- Bumped the base image in `docker/test-and-publish/Dockerfile` from `node:18-bullseye` to `node:24-bullseye` to align the container with the workflows.

### Testing

- No repository unit tests were modified by this PR and no automated test runs are included in the change itself.
- CI workflows will validate these updates when run in GitHub Actions after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f0f2270e88328a06cd5ebf6683939)