### PR TITLE
Update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: "https://npm.pkg.github.com"

--- a/.github/actions/private/push-submodules-to-pr/action.yml
+++ b/.github/actions/private/push-submodules-to-pr/action.yml
@@ -32,7 +32,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up SSH key for submodule access
-      uses: webfactory/ssh-agent@v0.8.0
+      uses: webfactory/ssh-agent@v0.10.0
       with:
         ssh-private-key: ${{ inputs.submodule_deploy_keys }}
 

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -63,11 +63,11 @@ jobs:
         working-directory: ${{ inputs.konfig_yaml_dir }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           version: 8

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -117,7 +117,7 @@ jobs:
           TEST_ENV: ${{ secrets.TEST_ENV }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
@@ -139,7 +139,7 @@ jobs:
       # If any SDKs are in submodules, then publishing might require pushing tags to the submodule repos
       - name: Set up SSH key for submodule access
         if: needs.pre-publish.outputs.sdk_submodule_dirs != '' && (matrix.language == 'php' || matrix.language == 'php7')
-        uses: webfactory/ssh-agent@v0.7.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ secrets.SUBMODULE_DEPLOY_KEY_PYTHON }}

--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -47,11 +47,11 @@ jobs:
           submodules: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           version: 8
@@ -149,7 +149,7 @@ jobs:
         uses: passiv/konfig-workflows/.github/actions/install-cli@main
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 


### PR DESCRIPTION
### Motivation
- GitHub Actions is deprecating Node.js 20 and will force Node.js 24 for JavaScript actions, so workflows and composite actions must use action versions compatible with Node 24 to avoid runtime deprecation and failures. 

### Description
- Bumped `actions/setup-node` references to `@v6` across workflows and composite actions to target Node.js 24. 
- Upgraded `pnpm/action-setup` from `@v2` to `@v6` in relevant workflows to ensure compatibility. 
- Updated `webfactory/ssh-agent` usages to `@v0.10.0` where present. 
- Files modified: `.github/workflows/regenerate-sdks.yaml`, `.github/workflows/bump.yaml`, `.github/workflows/publish.yaml`, `.github/actions/install-cli/action.yml`, and `.github/actions/private/push-submodules-to-pr/action.yml`.

### Testing
- Verified removal of deprecated references with `rg -n "actions/setup-node@v3|actions/setup-node@v5|pnpm/action-setup@v2|webfactory/ssh-agent@v0.7.0|webfactory/ssh-agent@v0.8.0" .github` which returned no matches. 
- Confirmed working tree is clean after changes with `git status --short`. 
- Changes were committed successfully (commit message: `Update GitHub actions for Node.js 24 compatibility`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a14a18d94bc83288c086619a8eb2e1a)