### PR TITLE
Fix regeneration head branch checkout

### DIFF
--- a/.github/workflows/regenerate-sdks.yaml
+++ b/.github/workflows/regenerate-sdks.yaml
@@ -130,7 +130,15 @@ jobs:
           git config --global user.name "Passiv Ops"
 
       - name: Create generated changes branch
-        run: git checkout -B "${{ steps.branches.outputs.head_branch }}"
+        env:
+          HEAD_BRANCH: ${{ steps.branches.outputs.head_branch }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$HEAD_BRANCH" >/dev/null; then
+            git fetch origin "$HEAD_BRANCH"
+            git checkout -B "$HEAD_BRANCH" "FETCH_HEAD"
+          else
+            git checkout -B "$HEAD_BRANCH"
+          fi
 
       - name: Detect SDK submodules
         id: sdk-submodules


### PR DESCRIPTION
### Motivation
- Prevent non-fast-forward push failures when the caller-provided `head_branch` already exists remotely by ensuring the workflow uses the remote branch history before committing regenerated SDK changes.
- Keep the existing behavior of creating a new head branch from the checked-out base branch when no remote head branch exists.

### Description
- Replace the simple `git checkout -B "${{ steps.branches.outputs.head_branch }}"` with logic that checks `origin` for the `HEAD_BRANCH` and, if present, fetches it and checks out `FETCH_HEAD` into the local branch.
- Preserve the fallback that creates a new local branch from the checked-out base branch when the remote head branch does not exist.
- Continue to use the resolved `head_branch` output for downstream steps so submodule pushes and merges target the caller-provided branch.

### Testing
- Ran YAML validation with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/regenerate-sdks.yaml"); puts "yaml ok"'` which succeeded.
- Ran `git diff --check` which reported no issues.
- Attempted Python `yaml` check which failed due to a missing `yaml` module in the environment (not a problem for the workflow itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a43c7f062748328a24f80750a746b96)